### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ t__ is also available on [HEX](https://hex.pm/packages/t&lowbar;&lowbar;/)
 | 2   | gettext contexts                                                      | YES                                                   | NO                                                      |
 | 3   | gettext plural terms                                                  | YES                                                   | NO                                                      |
 | 4   | Separate configurations for each application started at the same node | YES                                                   | NO                                                      |
-| 5   | Diffrent language sources                                             | YES: using application 'repositories'                 | YES: using diffrent languages servers                   |
+| 5   | Different language sources                                             | YES: using application 'repositories'                 | YES: using different languages servers                   |
 | 6   | Developer mode/monitoring PO file changes                             | YES: automatically detecting PO changes               | NO: requires manual reloading of the PO files           |
 | 7   | Cache                                                                 | YES: ETS reads/writes on the calling process (faster) | YES: ETS reads/writes inside the translation gen_server |
 
 ## Limitations
 
-- Gettext plural-forms formulas are hardcoded using a database. Work is underway to bypass this limitation and provide a full interpretor of any arbitrary gettext C formula.
+- Gettext plural-forms formulas are hardcoded using a database. Work is underway to bypass this limitation and provide a full interpreter of any arbitrary gettext C formula.
 
 ## Documentation
 
@@ -59,7 +59,7 @@ You can test this feature by modifying any PO files used by the demoapp while yo
 
 #### Set the language
 
-It is higly recommended to set the calling process language in order to avoid specifying the language for each ?T__ macro call.
+It is highly recommended to set the calling process language in order to avoid specifying the language for each ?T__ macro call.
 The specified language will be used by all ?T__ macros and functions for the current process if no explicit language is specified as a macro or function parameter.
 
 ```erlang
@@ -80,7 +80,7 @@ The function will perform the following steps in order to determine the default 
 - call application:get_env(t__language)
 - call application:get_env(t__, t__language)
 - if no t__language environment key was set for both the current application or the t__ application
-we return t__ default language defined in t__.hrl file (wich is "en").
+we return t__ default language defined in t__.hrl file (which is "en").
 
 ```erlang
 Language = ?T__LANGUAGE().
@@ -200,7 +200,7 @@ Short answer: Yes, if you trust CLDR Project.
 
 ### How plural formulas where generated from CLDR?
 
-For mantaining plural formulas database we started another project here: [gettext-po-samples](https://github.com/ergenius/gettext-po-samples)
+For maintaining plural formulas database we started another project here: [gettext-po-samples](https://github.com/ergenius/gettext-po-samples)
 
 We use the following sources and tools for compiling the database:
 

--- a/demoapp/src/demoapp_srv.erl
+++ b/demoapp/src/demoapp_srv.erl
@@ -248,7 +248,7 @@ terminate(_Reason, _State) -> ok.
 
 %% @doc Handle gen_server code change
 %% This function is called by a gen_server process when it is to update its internal state during a release upgrade/downgrade,
-%% that is, when the instruction {update,Module,Change,...}, where Change={advanced,Extra}, is specifed in the appup file.
+%% that is, when the instruction {update,Module,Change,...}, where Change={advanced,Extra}, is specified in the appup file.
 %% For more information, see section Release Handling Instructions in OTP Design Principles.
 %%
 %% For an upgrade, OldVsn is Vsn, and for a downgrade, OldVsn is {down,Vsn}. Vsn is defined by the vsn attribute(s) of the old version

--- a/include/t__.hrl
+++ b/include/t__.hrl
@@ -17,7 +17,7 @@
 %% Default language code string.
 %% 
 %% Don't edit this! Overwrite it using the following ways:
-%% - call TL__("language_code") in your process to setup the language per process. Best performance/higly recommended.
+%% - call TL__("language_code") in your process to setup the language per process. Best performance/highly recommended.
 %% - call t__:config/1 or t__:config/2 to configure the language at the application level
 %% - set the t__config environment variable for your application
 %% - set the t__config environment variable for the t__ application. NOT recommended because 
@@ -85,7 +85,7 @@
 	%%
 	%% When in developer mode the t__srv monitor monitor PO file changes and
 	%% collect all untranslated strings. The repository PO files translations
-	%% are still cached into an ETS table but the cache is evicted everytime the PO
+	%% are still cached into an ETS table but the cache is evicted every time the PO
 	%% files are modified.
 	%%
 	%% If dev mode is false, no untranslated strings are collected.
@@ -134,7 +134,7 @@
 	%%
 	%% It should contain a reference to the program’s source code related to the msgid
 	%% you want to translate. This information can be used by the translator to
-	%% locate and understand the context from where the message is comming.
+	%% locate and understand the context from where the message is coming.
 	%% If you use the T__ macro this information is automatically set using
 	%% ?FILE:?LINE ?MODULE:?FUNCTION_NAME/?FUNCTION_ARITY format.
 	reference = undefined :: undefined | string()
@@ -166,12 +166,12 @@
 -define(T__LANGUAGE(Language), erlang:put(t__language, Language)).
 
 %% Macro for creating a gettext reference
-%% Refrence information is added as a comment line starting with #: 
+%% Reference information is added as a comment line starting with #: 
 %% into the generated POT file above the msgid.
 %%
 %% It should contain a reference to the program’s source code related to the msgid 
 %% you want to translate. This information can be used by the translator to
-%% locate and understand the context from where the message is comming.
+%% locate and understand the context from where the message is coming.
 %% If you use the T__ macro this information is automatically collected using 
 %% ?FILE:?LINE ?MODULE:?FUNCTION_NAME/?FUNCTION_ARITY format
 -define(T__REFERENCE(), io_lib:format("~p:~p - ~p:~p/~p", [?FILE, ?LINE, ?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY])).

--- a/src/t__srv.erl
+++ b/src/t__srv.erl
@@ -191,7 +191,7 @@ terminate(_Reason, State) -> private_handle_terminate(State).
 
 %% @doc Handle gen_server code change
 %% This function is called by a gen_server process when it is to update its internal state during a release upgrade/downgrade,
-%% that is, when the instruction {update,Module,Change,...}, where Change={advanced,Extra}, is specifed in the appup file.
+%% that is, when the instruction {update,Module,Change,...}, where Change={advanced,Extra}, is specified in the appup file.
 %% For more information, see section Release Handling Instructions in OTP Design Principles.
 %%
 %% For an upgrade, OldVsn is Vsn, and for a downgrade, OldVsn is {down,Vsn}. Vsn is defined by the vsn attribute(s) of the old version
@@ -321,7 +321,7 @@ private_update_application(ApplicationName, [Repository = #t__repository{}|T], A
 		{ok, NewRepository} -> private_update_application(ApplicationName, T, [NewRepository|Acum]);
 		Error ->
 			?T__LOG(error, "Updating application repository failed with error."
-			" Repository directory does not exist or it is not accesible.",
+			" Repository directory does not exist or it is not accessible.",
 				[
 					{application, ApplicationName},
 					{repository, Repository},


### PR DESCRIPTION
Found via `codespell -S doc -L fo,nd,seh,te,caractere`